### PR TITLE
feat(12): considering ratings in 'get_articles'; typo fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 TARGET = ./target/wasm32-unknown-unknown/release/blockipedia_near.wasm
 
+TEST_TARGET=""
+
 test:
-	cargo test
+	cargo test $(TEST_TARGET)
+
+# enable `println!()` to show up in the console
+# see more at https://stackoverflow.com/a/25107081/3429055
+test-verbose:
+	cargo test $(TEST_TARGET) -- --nocapture
 
 build:
 	cargo build --target wasm32-unknown-unknown --release

--- a/README.md
+++ b/README.md
@@ -2,3 +2,28 @@
 A wikipedia on NEAR Protocol
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/nlhkh/blockipedia-near)
+
+# How to run tests
+
+## Run tests against the entire suite
+
+```bash
+make test
+```
+
+## Run test for a single unit test
+
+```bash
+make test TEST_TARGET=test_name
+# where `test_name` is the name of the specific test function
+# e.g. "create_article_with_insufficient_fund"
+```
+
+## Run tests while allowing console log messages (e.g. from `println!` or `dbg!`) to show up
+
+```bash
+# run all tests
+make test-verbose
+# run a specific test
+make test-verbose TEST_TARGET=test_name
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use models::{Article, ArticleMeta, Rating, RatingAction, ONE_NEAR};
 mod constants;
 use constants::ERR_ARTICLE_NOT_FOUND;
 
+// the upvote/downvote ratio, below which the article is hidden away (#12)
+const ARTICLE_VISIBILITY_VOTING_RATIO: f32 = 3.0 / 7.0;
+
 near_sdk::setup_alloc!();
 
 #[near_bindgen]
@@ -58,13 +61,43 @@ impl Wiki {
             author: meta.author,
             published_date: meta.published_date,
             upvote: rating.upvote,
-            download: rating.downvote,
+            downvote: rating.downvote,
         };
     }
 
     // Get a list of articles
     pub fn get_articles(&self) -> Vec<(u64, ArticleMeta)> {
-        return self.meta.to_vec();
+
+        #[cfg(test)]
+        println!("\ninvoking `get_articles`...");
+
+        let mut articles = self.meta.to_vec();
+        articles.retain(|rec| {
+
+            let (id, _) = rec;
+            let ratings = self.ratings.get(id).unwrap_or(Rating {
+                upvote: 0,
+                downvote: 0,
+            });
+            let mut ups = ratings.upvote;
+            let mut downs = ratings.downvote;
+
+            // prevent the "division by 0" case
+            if downs == 0 { ups += 1; downs += 1; }
+
+            let ratio: f32 = ups as f32 / downs as f32;
+
+            #[cfg(test)]
+            println!("record {:?}: up {:?}, down {:?}, ratio {:.2}, threshold {:.2}", id, ups, downs, ratio, ARTICLE_VISIBILITY_VOTING_RATIO);
+
+            return ratio.gt(&ARTICLE_VISIBILITY_VOTING_RATIO);
+
+        });
+
+        #[cfg(test)]
+        println!("done invoking `get_articles`\n");
+
+        return articles;
     }
 
     // Create a new article for 2 NEARs
@@ -216,6 +249,56 @@ mod tests {
             "Incorrect published date"
         );
         assert_eq!(article1.author, "robert.testnet", "Incorrect author");
+    }
+
+    #[test]
+    fn get_articles() {
+        let context = get_context(vec![], false, 10 * ONE_NEAR);
+        testing_env!(context);
+
+        //----------------------------------------------------------
+        // should return all articles if non of them has any rating
+
+        let mut contract = Wiki::default();
+        let mut articles = contract.get_articles();
+        assert_eq!(articles.len(), 0, "Initial number of articles must be zero");
+
+        contract.create_article(
+            String::from("Test article 1"),
+            String::from("This is a content of the test article 1."),
+        );
+        articles = contract.get_articles();
+        assert_eq!(articles.len(), 1, "Number of articles must be 1 after creating one article");
+
+        contract.create_article(
+            String::from("Test article 2"),
+            String::from("This is a content of the test article 2."),
+        );
+        contract.create_article(
+            String::from("Test article 3"),
+            String::from("This is a content of the test article 3."),
+        );
+        articles = contract.get_articles();
+        assert_eq!(articles.len(), 3, "Number of articles must be 3 after creating three articles");
+
+        dbg!(articles.len(), articles);
+
+        //-------------------------------------------------------------------
+        // should return only articles with the desired upvote/downvote ratio
+
+        // 3 upvotes
+        for _ in 0..3 { contract.upvote(1); }
+
+        // 7 downvotes
+        for _ in 0..7 { contract.downvote(1); }
+
+        articles = contract.get_articles();
+        assert_eq!(articles.len(), 2, "Number of articles must be 2 after 1 article is downvoted too much");
+
+        contract.upvote(1);
+        articles = contract.get_articles();
+        assert_eq!(articles.len(), 3, "Number of articles must be 3 again after the hidden article achieves the desirable voting ratio");
+
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -12,9 +12,10 @@ pub struct Article {
     pub author: AccountId,
     pub published_date: u64,
     pub upvote: u8,
-    pub download: u8,
+    pub downvote: u8,
 }
 
+#[cfg_attr(test, derive(Debug))] // add Debug trait for this struct only when running tests
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct ArticleMeta {
     pub title: String,


### PR DESCRIPTION
This PR closes #12

Updated:
1. the implementation of `get_articles` now considers the upvote/downvote threshold of the articles
2. minor typo (`download` -> `downvote`)

Added:
1. the ability to run a single test (e.g. `make test TEST_TARGET=<test_name>`)
2. the ability to verbosely log out messages while running tests (e.g. `make test-verbose`)
3. unit test for the `get_articles` function
4. README docu (example `make test` commands)