### PR TITLE
near sdk to 4.0.0 upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blockipedia-near"
 version = "0.1.0"
-authors = ["Kha Nguyen <nlhkha@gmail.com>"]
+authors = ["Kha Nguyen <nlhkha@gmail.com>", "Khang Dinh <gate@dklab.co>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,9 +10,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk = "3.1.0"
-serde = "1.0"
-serde_json = { version = "1.0", features = ["raw_value"] }
+near-sdk = "4.0.0"
 
 [profile.release]
 codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test:
 test-verbose:
 	cargo test $(TEST_TARGET) -- --nocapture
 
+add-target:
+	rustup target add wasm32-unknown-unknown
+
 build:
 	cargo build --target wasm32-unknown-unknown --release
 
@@ -29,3 +32,6 @@ create-test-account:
 
 deploy-test:
 	near deploy test.blockipedia.testnet --wasmFile $(TARGET)
+
+clean:
+	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,18 @@ redeploy: clear-state deploy-dev
 create-test-account:
 	near create-account test.blockpedia.testnet --masterAccount blockipedia.testnet
 
+# deploy to the defacto testnet contract address
 deploy-test:
 	near deploy test.blockipedia.testnet --wasmFile $(TARGET)
 
+# deploy to a provided testnet contract address (given as an make cmd input argument)
+# e.g. `make CONTRACT_ID=dev-1654392200283-45248039192531 deploy-test-to
+deploy-test-to:
+	near deploy $(CONTRACT_ID) --accountId $(CONTRACT_ID) --wasmFile $(TARGET)
+
 clean:
 	cargo clean
+
+# @TODO consider a DX-friendly way to ensure dynamic .env file is supported
+build-frontend:
+	cd frontend && yarn && yarn build

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,6 +1,7 @@
-APP_NAME=Blockipedia
-HOSTNAME=https://nlhkh.github.io/blockipedia-near
-CONTRACT_ADDRESS=test.blockipedia.testnet
+GATSBY_APP_NAME=Blockipedia
+GATSBY_HOSTNAME=https://nlhkh.github.io/blockipedia-near
+GATSBY_CONTRACT_ADDRESS=test.blockipedia.testnet
+GATSBY_PATH_PREFIX=/blockipedia-near
 
 NEAR_NETWORK_ID=testnet
 NEAR_NODE_URL=https://rpc.testnet.near.org

--- a/frontend/.env.staging
+++ b/frontend/.env.staging
@@ -1,7 +1,8 @@
 GATSBY_APP_NAME=Blockipedia
-GATSBY_HOSTNAME=https://nlhkh.github.io/blockipedia-near
-GATSBY_CONTRACT_ADDRESS=test.blockipedia.testnet
-GATSBY_PATH_PREFIX=/blockipedia-near
+GATSBY_HOSTNAME=https://blockipedia.onrender.com
+GATSBY_CONTRACT_ADDRESS=dev-1654392200283-45248039192531
+GATSBY_PATH_PREFIX=/
+GATSBY_SITE_URL=https://blockipedia.onrender.com
 
 NEAR_NETWORK_ID=testnet
 NEAR_NODE_URL=https://rpc.testnet.near.org

--- a/frontend/gatsby-config.ts
+++ b/frontend/gatsby-config.ts
@@ -9,9 +9,9 @@ import type { GatsbyConfig } from "gatsby";
 const config: GatsbyConfig = {
   siteMetadata: {
     title: `Blockipedia`,
-    siteUrl: `https://nlhkh.github.io/blockipedia-near`
+    siteUrl: process.env.GATSBY_SITE_URL || `https://nlhkh.github.io/blockipedia-near`
   },
-  pathPrefix: process.env.GATSBY_PATH_PREFIX || "/blockipedia-near",
+  pathPrefix: process.env.GATSBY_PATH_PREFIX, // e.g. `/blockipedia-near` when served by GitHub Pages
   plugins: [
     "gatsby-plugin-postcss",
     "gatsby-plugin-react-helmet",

--- a/frontend/gatsby-config.ts
+++ b/frontend/gatsby-config.ts
@@ -2,6 +2,10 @@ if (process.env.DOTENV_PATH) {
   require("dotenv").config({
     path: process.env.DOTENV_PATH,
   })
+} else {
+  require("dotenv").config({
+    path: `.env.${process.env.NODE_ENV || 'development'}`,
+  })
 }
 
 import type { GatsbyConfig } from "gatsby";

--- a/frontend/gatsby-config.ts
+++ b/frontend/gatsby-config.ts
@@ -1,3 +1,9 @@
+if (process.env.DOTENV_PATH) {
+  require("dotenv").config({
+    path: process.env.DOTENV_PATH,
+  })
+}
+
 import type { GatsbyConfig } from "gatsby";
 
 const config: GatsbyConfig = {
@@ -5,7 +11,7 @@ const config: GatsbyConfig = {
     title: `Blockipedia`,
     siteUrl: `https://nlhkh.github.io/blockipedia-near`
   },
-  pathPrefix: "/blockipedia-near",
+  pathPrefix: process.env.GATSBY_PATH_PREFIX || "/blockipedia-near",
   plugins: [
     "gatsby-plugin-postcss",
     "gatsby-plugin-react-helmet",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "blockipedia",
   "author": "Kha",
+  "contributors": [
+    "Khang Dinh <gate@dklab.co>"
+  ],
   "keywords": [
     "gatsby"
   ],

--- a/frontend/src/components/nearAuth/index.tsx
+++ b/frontend/src/components/nearAuth/index.tsx
@@ -18,7 +18,7 @@ type ISmartContract = {
 const ContractContext = createContext<ISmartContract | undefined>(undefined)
 
 function getHostname(): string {
-    const hostname = process.env.HOSTNAME
+    const hostname = process.env.GATSBY_HOSTNAME
     if (hostname) {
         return hostname
     } else {

--- a/frontend/src/components/nearAuth/index.tsx
+++ b/frontend/src/components/nearAuth/index.tsx
@@ -39,7 +39,7 @@ export function ContractProvider(props: { children: ReactNode }) {
     useEffect(function () {
         getNearWallet().then(w => {
             setAuthenticated(w.isSignedIn())
-            const c = new Contract(w.account(), process.env.CONTRACT_ADDRESS!, {
+            const c = new Contract(w.account(), process.env.GATSBY_CONTRACT_ADDRESS!, {
                 viewMethods: ["get_article", "get_articles"],
                 changeMethods: ["create_article", "update_article", "upvote", "downvote", "donate"]
             })

--- a/frontend/src/near-wallet/index.ts
+++ b/frontend/src/near-wallet/index.ts
@@ -19,7 +19,7 @@ async function getNearWallet() {
 async function signIn(wallet: WalletConnection) {
     await wallet.requestSignIn(
         process.env.GATSBY_CONTRACT_ADDRESS,
-        process.env.APP_NAME
+        process.env.GATSBY_APP_NAME
     )
 }
 

--- a/frontend/src/near-wallet/index.ts
+++ b/frontend/src/near-wallet/index.ts
@@ -18,7 +18,7 @@ async function getNearWallet() {
 
 async function signIn(wallet: WalletConnection) {
     await wallet.requestSignIn(
-        process.env.CONTRACT_ADDRESS,
+        process.env.GATSBY_CONTRACT_ADDRESS,
         process.env.APP_NAME
     )
 }

--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,6 @@ services:
   - key: GATSBY_CONTRACT_ADDRESS
     value: test.blockipedia.testnet
     previewValue: dev-1654392200283-45248039192531
+  - key: GATSBY_PATH_PREFIX
+    value: /
+    previewValue: /

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ previewsEnabled: false # see https://render.com/docs/preview-environments
 previewsExpireAfterDays: 3
 services:
 - type: web
-  name: blockipedia-frontend
+  name: blockipedia
   env: static
   buildCommand: cd frontend; yarn; yarn build
   staticPublishPath: ./frontend/public

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+previewsEnabled: true
+previewsExpireAfterDays: 3
+services:
+- type: web
+  name: blockipedia
+  env: static
+  buildCommand: cd frontend; yarn; yarn build
+  staticPublishPath: ./frontend/public
+  envVars:
+  - key: GATSBY_CONTRACT_ADDRESS
+    value: test.blockipedia.testnet
+    previewValue: dev-1654392200283-45248039192531

--- a/render.yaml
+++ b/render.yaml
@@ -1,15 +1,16 @@
-previewsEnabled: true
+previewsEnabled: false # see https://render.com/docs/preview-environments
 previewsExpireAfterDays: 3
 services:
 - type: web
-  name: blockipedia
+  name: blockipedia-frontend
   env: static
   buildCommand: cd frontend; yarn; yarn build
   staticPublishPath: ./frontend/public
+  pullRequestPreviewsEnabled: true  # see https://render.com/docs/pull-request-previews
   envVars:
   - key: GATSBY_CONTRACT_ADDRESS
     value: test.blockipedia.testnet
-    previewValue: dev-1654392200283-45248039192531
+    previewValue: dev-1654392200283-45248039192531  # only applicable to PreviewEnvironments
   - key: GATSBY_PATH_PREFIX
     value: /
-    previewValue: /
+    previewValue: /  # only applicable to PreviewEnvironments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,9 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::UnorderedMap;
-use near_sdk::{env, init, near_bindgen, AccountId, Promise};
+use near_sdk::{env, near_bindgen, AccountId, Promise};
 
 mod models;
 use models::{Article, ArticleMeta, Rating, RatingAction, ONE_NEAR};
-
-#[cfg(test)]
-use models::ParsedReceipt;
 
 mod utils;
 use utils::f32_to_ynear;
@@ -21,8 +18,6 @@ const ARTICLE_VISIBILITY_VOTING_RATIO: f64 = 3.0 / 7.0;
 const MIN_DONATION_AMOUNT: u128 = f32_to_ynear(1.0); // 1 $NEAR in yoctoNEAR
 const MAX_DONATION_AMOUNT: u128 = f32_to_ynear(100.0); // 100 $NEAR in yoctoNEAR
 
-near_sdk::setup_alloc!();
-
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct Wiki {
@@ -32,7 +27,6 @@ pub struct Wiki {
 }
 
 impl Default for Wiki {
-    #[init]
     fn default() -> Self {
         Self {
             meta: UnorderedMap::new(b"meta".to_vec()),
@@ -52,6 +46,7 @@ impl Wiki {
     }
 
     // Get an article
+    #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_article(&self, article_id: u64) -> Article {
         let meta = self.meta.get(&article_id).unwrap_or(ArticleMeta {
             title: String::from("Not found"),
@@ -81,11 +76,12 @@ impl Wiki {
     fn panic_on_nonexistent_article(&self, article_id: u64) {
         let meta = self.meta.get(&article_id);
         if meta.is_none() {
-            env::panic(ERR_ARTICLE_NOT_FOUND.as_bytes());
+            env::panic_str(ERR_ARTICLE_NOT_FOUND);
         }
     }
 
     // Get a list of articles
+    #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_articles(&self) -> Vec<(u64, ArticleMeta)> {
         #[cfg(test)]
         println!("\ninvoking `get_articles`...");
@@ -127,20 +123,20 @@ impl Wiki {
     #[payable]
     pub fn create_article(&mut self, title: String, content: String) -> u64 {
         if env::attached_deposit() < 2 * ONE_NEAR {
-            env::panic("Not enough fund to create article".as_bytes());
+            env::panic_str("Not enough fund to create article");
         }
 
         let author = env::signer_account_id();
         let editor = author.clone();
         let published_date = env::block_timestamp();
 
-        env::log(format!("Article created at {}", published_date).as_bytes());
+        env::log_str(format!("Article created at {}", published_date).as_str());
 
         let article_id = self.corpus.len();
 
         let meta = ArticleMeta {
             title,
-            author,
+            author: author.to_string(),
             editors: vec![editor],
             published_date,
         };
@@ -155,7 +151,7 @@ impl Wiki {
     #[payable]
     pub fn update_article(&mut self, article_id: u64, content: String) {
         if env::attached_deposit() < ONE_NEAR / 2 {
-            env::panic("Not enough fund to update article".as_bytes());
+            env::panic_str("Not enough fund to update article");
         }
 
         let editor = env::signer_account_id();
@@ -167,7 +163,7 @@ impl Wiki {
                 self.corpus.insert(&article_id, &content);
                 self.meta.insert(&article_id, &meta);
             }
-            None => env::panic(ERR_ARTICLE_NOT_FOUND.as_bytes()),
+            None => env::panic_str(ERR_ARTICLE_NOT_FOUND),
         }
     }
 
@@ -207,21 +203,19 @@ impl Wiki {
         let donation_amt: u128 = env::attached_deposit();
 
         if donation_amt.lt(&MIN_DONATION_AMOUNT) {
-            env::panic(
+            env::panic_str(
                 format!(
                     "Donation amount cannot be less than {:?}",
                     MIN_DONATION_AMOUNT
-                )
-                .as_bytes(),
+                ).as_str(),
             );
         }
         if donation_amt.gt(&MAX_DONATION_AMOUNT) {
-            env::panic(
+            env::panic_str(
                 format!(
                     "Donation amount cannot be greater than {:?}",
                     MAX_DONATION_AMOUNT
-                )
-                .as_bytes(),
+                ).as_str(),
             );
         }
 
@@ -238,35 +232,37 @@ impl Wiki {
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use near_sdk::test_utils::get_created_receipts;
-    use near_sdk::{testing_env, MockedBlockchain, VMContext};
 
-    fn get_context(input: Vec<u8>, is_view: bool, deposit: u128) -> VMContext {
-        // see more at https://docs.rs/near-sdk/latest/near_sdk/struct.VMContext.html
-        VMContext {
-            current_account_id: "blockipedia.localnet".to_string(),
-            signer_account_id: "user.localnet".to_string(),
-            signer_account_pk: vec![0, 1, 2],
-            predecessor_account_id: "user.localnet".to_string(),
-            input,
-            block_index: 0,
-            block_timestamp: 0,
-            account_balance: ONE_NEAR * 10,
-            account_locked_balance: ONE_NEAR * 10,
-            storage_usage: 0,
-            attached_deposit: deposit,
-            prepaid_gas: 10u64.pow(18),
-            random_seed: vec![0, 1, 2],
-            is_view,
-            output_data_receivers: vec![],
-            epoch_height: 19,
-        }
+    use super::*;
+    use near_sdk::test_utils::{get_created_receipts, VMContextBuilder};
+    use near_sdk::{testing_env, Gas, VMContext};
+
+    fn get_context(is_view: bool, deposit: u128) -> VMContext {
+        // see more at
+        // - https://www.near-sdk.io/testing/unit-tests
+        // - https://docs.rs/near-sdk/latest/near_sdk/struct.VMContext.html
+        // - https://docs.rs/near-sdk/latest/near_sdk/test_utils/struct.VMContextBuilder.html
+        VMContextBuilder::new()
+            .current_account_id("blockipedia.localnet".parse().unwrap())
+            .signer_account_id("user.localnet".parse().unwrap())
+            .signer_account_pk(vec![0u8; 33].try_into().unwrap())
+            .predecessor_account_id("user.localnet".parse().unwrap())
+            .block_index(0)
+            .block_timestamp(0)
+            .account_balance(ONE_NEAR * 10)
+            .account_locked_balance(ONE_NEAR * 10)
+            .storage_usage(0)
+            .attached_deposit(deposit)
+            .prepaid_gas(Gas::from(10u64.pow(18)))
+            .random_seed([0u8; 32])
+            .is_view(is_view)
+            .epoch_height(0)
+            .build()
     }
 
     #[test]
     fn create_an_article() {
-        let context = get_context(vec![], false, 2 * ONE_NEAR);
+        let context = get_context(false, 2 * ONE_NEAR);
         testing_env!(context);
 
         let mut contract = Wiki::default();
@@ -308,7 +304,7 @@ mod tests {
 
     #[test]
     fn get_articles() {
-        let context = get_context(vec![], false, 10 * ONE_NEAR);
+        let context = get_context(false, 10 * ONE_NEAR);
         testing_env!(context);
 
         //----------------------------------------------------------
@@ -374,7 +370,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Not enough fund to create article")]
     fn create_article_with_insufficient_fund() {
-        let context = get_context(vec![], false, ONE_NEAR);
+        let context = get_context(false, ONE_NEAR);
         testing_env!(context);
 
         let mut contract = Wiki::default();
@@ -387,7 +383,7 @@ mod tests {
 
     #[test]
     fn update_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 3);
+        let context = get_context(false, ONE_NEAR * 3);
         testing_env!(context);
 
         let mut contract = Wiki::default();
@@ -407,7 +403,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Not enough fund to update article")]
     fn update_article_with_insufficient_fund() {
-        let context = get_context(vec![], false, ONE_NEAR / 2 - 1);
+        let context = get_context(false, ONE_NEAR / 2 - 1);
         testing_env!(context);
 
         let mut contract = Wiki::default();
@@ -418,7 +414,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Article not found")]
     fn panic_on_nonexistent_article() {
-        let context = get_context(vec![], true, 0);
+        let context = get_context(true, 0);
         testing_env!(context);
         let contract = Wiki::default();
         contract.panic_on_nonexistent_article(0);
@@ -427,7 +423,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Article not found")]
     fn update_nonexistent_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 3);
+        let context = get_context(false, ONE_NEAR * 3);
         testing_env!(context);
 
         let mut contract = Wiki::default();
@@ -438,7 +434,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Article not found")]
     fn do_upvote_on_nonexistent_article() {
-        let context = get_context(vec![], true, 0);
+        let context = get_context(true, 0);
         testing_env!(context);
         let mut contract = Wiki::default();
         contract.upvote(0);
@@ -447,7 +443,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Article not found")]
     fn do_downvote_on_nonexistent_article() {
-        let context = get_context(vec![], true, 0);
+        let context = get_context(true, 0);
         testing_env!(context);
         let mut contract = Wiki::default();
         contract.downvote(0);
@@ -455,7 +451,7 @@ mod tests {
 
     #[test]
     fn do_upvote_on_existing_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         let id = contract.create_article(String::from("Title"), String::from("Content"));
@@ -466,7 +462,7 @@ mod tests {
 
     #[test]
     fn do_downvote_on_existent_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         let id = contract.create_article(String::from("Title"), String::from("Content"));
@@ -478,7 +474,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Article not found")]
     fn donate_to_nonexistent_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         contract.donate(0);
@@ -487,12 +483,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "Donation amount cannot be less than")]
     fn donate_too_little_to_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         let id = contract.create_article(String::from("Title"), String::from("Content"));
 
-        let context = get_context(vec![], false, 999_000_000_000_000_000_000_000); // 0.999 $NEAR
+        let context = get_context(false, 999_000_000_000_000_000_000_000); // 0.999 $NEAR
         testing_env!(context);
         contract.donate(id);
     }
@@ -500,36 +496,32 @@ mod tests {
     #[test]
     #[should_panic(expected = "Donation amount cannot be greater than")]
     fn donate_too_much_to_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         let id = contract.create_article(String::from("Title"), String::from("Content"));
 
-        let context = get_context(vec![], false, 100_010_000_000_000_000_000_000_000); // 100.01 $NEAR
+        let context = get_context(false, 100_010_000_000_000_000_000_000_000); // 100.01 $NEAR
         testing_env!(context);
         contract.donate(id);
     }
 
     #[test]
     fn donate_successfully_to_article() {
-        let context = get_context(vec![], false, ONE_NEAR * 2);
+        let context = get_context(false, ONE_NEAR * 2);
         testing_env!(context);
         let mut contract = Wiki::default();
         let id = contract.create_article(String::from("Title"), String::from("Content"));
 
-        let context = get_context(vec![], false, ONE_NEAR * 3 / 2);
+        let context = get_context(false, ONE_NEAR * 3 / 2);
         testing_env!(context);
         contract.donate(id);
 
         let mut receipts = get_created_receipts();
         receipts.retain(|r| {
-            let raw_receipt = serde_json::value::to_raw_value(&r).unwrap();
-            let raw_receipt_str = raw_receipt.get();
-            let parsed_receipt: Result<ParsedReceipt, _> = serde_json::from_str(raw_receipt_str);
-            dbg!(&parsed_receipt);
-            let obj = parsed_receipt.unwrap();
-            return obj.receiver_id == "user.localnet"
-                && obj.actions[0].Transfer.deposit == ONE_NEAR * 3 / 2;
+            dbg!(r);
+            r.receiver_id == "user.localnet".parse().unwrap()
+                && r.actions.eq(&[near_sdk::mock::VmAction::Transfer { deposit: ONE_NEAR * 3 / 2 }])
         });
         assert_eq!(receipts.len(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ impl Wiki {
     }
 
     // Get an article
+    // @TODO check if serde_json::Serialize is needed for the FE client to consume
     #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_article(&self, article_id: u64) -> Article {
         let meta = self.meta.get(&article_id).unwrap_or(ArticleMeta {
@@ -81,6 +82,7 @@ impl Wiki {
     }
 
     // Get a list of articles
+    // @TODO check if serde_json::Serialize is needed for the FE client to consume
     #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_articles(&self) -> Vec<(u64, ArticleMeta)> {
         #[cfg(test)]
@@ -207,7 +209,8 @@ impl Wiki {
                 format!(
                     "Donation amount cannot be less than {:?}",
                     MIN_DONATION_AMOUNT
-                ).as_str(),
+                )
+                .as_str(),
             );
         }
         if donation_amt.gt(&MAX_DONATION_AMOUNT) {
@@ -215,7 +218,8 @@ impl Wiki {
                 format!(
                     "Donation amount cannot be greater than {:?}",
                     MAX_DONATION_AMOUNT
-                ).as_str(),
+                )
+                .as_str(),
             );
         }
 
@@ -521,7 +525,9 @@ mod tests {
         receipts.retain(|r| {
             dbg!(r);
             r.receiver_id == "user.localnet".parse().unwrap()
-                && r.actions.eq(&[near_sdk::mock::VmAction::Transfer { deposit: ONE_NEAR * 3 / 2 }])
+                && r.actions.eq(&[near_sdk::mock::VmAction::Transfer {
+                    deposit: ONE_NEAR * 3 / 2,
+                }])
         });
         assert_eq!(receipts.len(), 1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,6 @@ impl Wiki {
     }
 
     // Get an article
-    // @TODO check if serde_json::Serialize is needed for the FE client to consume
-    #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_article(&self, article_id: u64) -> Article {
         let meta = self.meta.get(&article_id).unwrap_or(ArticleMeta {
             title: String::from("Not found"),
@@ -82,8 +80,6 @@ impl Wiki {
     }
 
     // Get a list of articles
-    // @TODO check if serde_json::Serialize is needed for the FE client to consume
-    #[result_serializer(borsh)] // see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
     pub fn get_articles(&self) -> Vec<(u64, ArticleMeta)> {
         #[cfg(test)]
         println!("\ninvoking `get_articles`...");

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::AccountId;
 use near_sdk::serde::Serialize;
+use near_sdk::AccountId;
 
 pub static ONE_NEAR: u128 = 10u128.pow(24);
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,10 +1,13 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::AccountId;
+use near_sdk::serde::Serialize;
 
 pub static ONE_NEAR: u128 = 10u128.pow(24);
 
-// @TODO check if serde_json::Serialize is needed for the FE client to consume
-#[derive(BorshSerialize, BorshDeserialize)]
+// see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
+// see https://www.near-sdk.io/best-practices#reuse-crates-from-near-sdk
+#[derive(BorshSerialize, BorshDeserialize, Serialize)]
+#[serde(crate = "near_sdk::serde")]
 pub struct Article {
     pub id: u64,
     pub title: String,
@@ -15,9 +18,11 @@ pub struct Article {
     pub downvote: u8,
 }
 
-// @TODO check if serde_json::Serialize is needed for the FE client to consume
+// see https://www.near-sdk.io/contract-interface/serialization-interface#overriding-serialization-protocol-default
+// see https://www.near-sdk.io/best-practices#reuse-crates-from-near-sdk
 #[cfg_attr(test, derive(Debug))] // add Debug trait for this struct only when running tests
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize)]
+#[serde(crate = "near_sdk::serde")]
 pub struct ArticleMeta {
     pub title: String,
     pub author: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,7 @@ use near_sdk::AccountId;
 
 pub static ONE_NEAR: u128 = 10u128.pow(24);
 
+// @TODO check if serde_json::Serialize is needed for the FE client to consume
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct Article {
     pub id: u64,
@@ -14,6 +15,7 @@ pub struct Article {
     pub downvote: u8,
 }
 
+// @TODO check if serde_json::Serialize is needed for the FE client to consume
 #[cfg_attr(test, derive(Debug))] // add Debug trait for this struct only when running tests
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct ArticleMeta {

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,25 +1,24 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::AccountId;
-use serde::{Deserialize, Serialize};
 
 pub static ONE_NEAR: u128 = 10u128.pow(24);
 
-#[derive(Serialize)]
+#[derive(BorshSerialize, BorshDeserialize)]
 pub struct Article {
     pub id: u64,
     pub title: String,
     pub content: String,
-    pub author: AccountId,
+    pub author: String,
     pub published_date: u64,
     pub upvote: u8,
     pub downvote: u8,
 }
 
 #[cfg_attr(test, derive(Debug))] // add Debug trait for this struct only when running tests
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(BorshSerialize, BorshDeserialize)]
 pub struct ArticleMeta {
     pub title: String,
-    pub author: AccountId,
+    pub author: String,
     pub editors: Vec<AccountId>,
     pub published_date: u64,
 }
@@ -33,27 +32,4 @@ pub struct Rating {
 pub enum RatingAction {
     Upvote,
     Downvote,
-}
-
-#[cfg(test)]
-#[cfg_attr(test, derive(Debug))]
-#[derive(Serialize, Deserialize)]
-pub struct ParsedReceiptTransfer {
-    pub deposit: u128,
-}
-
-#[cfg(test)]
-#[cfg_attr(test, derive(Debug))]
-#[derive(Serialize, Deserialize)]
-#[allow(non_snake_case)]
-pub struct ParsedReceiptAction {
-    pub Transfer: ParsedReceiptTransfer,
-}
-
-#[cfg(test)]
-#[cfg_attr(test, derive(Debug))]
-#[derive(Serialize, Deserialize)]
-pub struct ParsedReceipt<'a> {
-    pub receiver_id: &'a str,
-    pub actions: Vec<ParsedReceiptAction>,
 }


### PR DESCRIPTION
This PR has been deployed to https://blockipedia.onrender.com/ , it:
- upgraded near sdk to 4.0.0
- updated build & deployment mechanism so we can now:
    - still develop on local e.g. under http://localhost:8000
    - serve production on GitHub Pages i.e. https://nlhkh.github.io/blockipedia-near/
    - serve staging (e.g. this branch) on another service (currently render.com is selected)

After merging to `main`, there might be additional deployment strategy updates, but that can follow. The main point is to make sure the upgrade to near sdk 4.0.0 doesn't cause any regression issue (by testing directly at https://blockipedia.onrender.com/)